### PR TITLE
Update DiffusionWeightedVolumeMasking.cxx

### DIFF
--- a/Modules/CLI/DiffusionWeightedVolumeMasking/DiffusionWeightedVolumeMasking.cxx
+++ b/Modules/CLI/DiffusionWeightedVolumeMasking/DiffusionWeightedVolumeMasking.cxx
@@ -66,7 +66,7 @@ int main( int argc, char * argv[] )
     for( int gradient_n = 0; gradient_n < grads->GetNumberOfTuples(); gradient_n++ )
       {
       double* gradient = grads->GetTuple3(gradient_n);
-      if( abs(gradient[0]) + abs(gradient[1]) + abs(gradient[2]) < GRAD_0_TOL )
+      if( fabs(gradient[0]) + fabs(gradient[1]) + fabs(gradient[2]) < GRAD_0_TOL )
         {
         vtkNew<vtkImageExtractComponents> extractComponents;
 #if (VTK_MAJOR_VERSION <= 5)


### PR DESCRIPTION
Compile was giving warnings because abs() function was used on data of type double. Now updated to use the fabs() function.

The updated line calculates the magnitude of each of the gradient, and determines that an image is "baseline" if the magnitude is smaller than a threshold. The use of abs() on doubles caused the magnitude to always be 0, and therefore all images were considered as "baseline" and included in the average computed by the filter and presented as "Output baseline volume" to the user. This bug was reported on Mantis with ID 0003855 on 2014-12-17. This update fixes this bug.
