### PR TITLE
BUG: Test remove islands functionality separately

### DIFF
--- a/Modules/CLI/DiffusionWeightedVolumeMasking/Testing/CMakeLists.txt
+++ b/Modules/CLI/DiffusionWeightedVolumeMasking/Testing/CMakeLists.txt
@@ -13,7 +13,6 @@ set(testname ${CLP}Test)
 add_test(NAME ${testname} COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
   ${testname}
     --otsuomegathreshold 0.5
-    --removeislands
     ${MRML_TEST_DATA}/helix-DWI.nhdr
     ${TEMP}/${CLP}_estimatedBaseline.nhdr
     ${TEMP}/${CLP}_output.nhdr


### PR DESCRIPTION
Updated files and command line for "BUG: Estimated output baseline image incorrect when using "DWI Volume Masking" (#380)" issue.
